### PR TITLE
Update labeler permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3


### PR DESCRIPTION
As per https://github.com/crazy-max/ghaction-github-labeler/issues/184, labeler requires permission to write to issues to work properly.